### PR TITLE
step/s optimization, especially for distributed training

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,6 +39,8 @@ parser.add_argument('data', metavar='DIR', nargs='?', default='imagenet',
                     help='path to dataset (default: imagenet)')
 parser.add_argument('-j', '--workers', default=4, type=int, metavar='N',
                     help='number of data loading workers (default: 4)')
+parser.add_argument('--prefetch-factor', default=2, type=int, metavar='N',
+                    help='number of batches for each worker to prefetch (default: 2)')
 parser.add_argument('--hidden-dim', default=384, type=int, metavar='N',
                     help='Embedding dimension of the ViT (default: 384)')
 parser.add_argument('--input-resolution', default=224, type=int, metavar='RES',
@@ -366,12 +368,12 @@ def main_worker(gpu, args):
         train_dataset, batch_size=args.batch_size, shuffle=(train_sampler is None),
         num_workers=args.workers, pin_memory=True, sampler=train_sampler,
         collate_fn=collate_fn, drop_last=True, multiprocessing_context='spawn',
-        persistent_workers=True, pin_memory_device=str(device))
+        prefetch_factor=args.prefetch_factor, persistent_workers=True, pin_memory_device=str(device))
 
     val_loader = torch.utils.data.DataLoader(
         val_dataset, batch_size=args.batch_size, shuffle=False,
         num_workers=args.workers, pin_memory=True, sampler=val_sampler,
-        multiprocessing_context='spawn', pin_memory_device=str(device))
+        multiprocessing_context='spawn', prefetch_factor=args.prefetch_factor, pin_memory_device=str(device))
 
     warmup = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=lambda step: step / args.warmup)
     cosine = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=total_steps - args.warmup)

--- a/main.py
+++ b/main.py
@@ -39,8 +39,8 @@ parser.add_argument('data', metavar='DIR', nargs='?', default='imagenet',
                     help='path to dataset (default: imagenet)')
 parser.add_argument('-j', '--workers', default=4, type=int, metavar='N',
                     help='number of data loading workers (default: 4)')
-parser.add_argument('--prefetch-factor', default=2, type=int, metavar='N',
-                    help='number of batches for each worker to prefetch (default: 2)')
+parser.add_argument('--prefetch-factor', default=1, type=int, metavar='N',
+                    help='number of batches for each worker to prefetch (default: 1)')
 parser.add_argument('--hidden-dim', default=384, type=int, metavar='N',
                     help='Embedding dimension of the ViT (default: 384)')
 parser.add_argument('--input-resolution', default=224, type=int, metavar='RES',

--- a/simple_vit.py
+++ b/simple_vit.py
@@ -5,6 +5,7 @@ from functools import partial
 from typing import Callable, Optional
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from torchvision.models.vision_transformer import MLPBlock
 
 
@@ -127,7 +128,6 @@ class SimpleVisionTransformer(nn.Module):
         pool_type: str = "gap",
         register: int = 0,
         norm_layer: Callable[..., torch.nn.Module] = partial(nn.LayerNorm, eps=1e-6),
-        loss: Callable[..., torch.nn.Module] = nn.CrossEntropyLoss,
     ):
         super().__init__()
         torch._assert(image_size % patch_size == 0, "Input shape indivisible by patch size!")
@@ -180,7 +180,6 @@ class SimpleVisionTransformer(nn.Module):
             heads_layers["head"] = nn.Linear(representation_size, num_classes)
 
         self.heads = nn.Sequential(heads_layers)
-        self.loss_fn = loss()
 
         # Init the patchify stem
         fan_in = self.conv_proj.in_channels * self.conv_proj.kernel_size[0] * self.conv_proj.kernel_size[1] // self.conv_proj.groups
@@ -215,7 +214,15 @@ class SimpleVisionTransformer(nn.Module):
 
         return x
 
-    def forward(self, x: torch.Tensor, target: torch.Tensor):
+    def _loss_fn(self, out: torch.Tensor, lam: float, target1: torch.Tensor, target2: torch.Tensor):
+        n = out.shape[0]
+        logprob = F.log_softmax(out, dim=1)
+        logp1 = logprob[torch.arange(n), target1]
+        logp2 = logprob[torch.arange(n), target2]
+        cross_entropy = logp1.mul_(-lam).add_(logp2, alpha=lam - 1.0)
+        return cross_entropy.mean()
+
+    def forward(self, x: torch.Tensor, lam: float, target1: torch.Tensor, target2: torch.Tensor):
         # Reshape and permute the input tensor
         x = self._process_input(x)
         if self.pos_embedding is not None:
@@ -230,5 +237,5 @@ class SimpleVisionTransformer(nn.Module):
             x = x[:, self.register:]
             x = x.mean(dim = 1)
         x = self.heads(x)
-        loss = self.loss_fn(x, target)
+        loss = self._loss_fn(x, lam, target1, target2)
         return x, loss

--- a/simple_vit.py
+++ b/simple_vit.py
@@ -217,10 +217,7 @@ class SimpleVisionTransformer(nn.Module):
     def _loss_fn(self, out: torch.Tensor, lam: float, target1: torch.Tensor, target2: torch.Tensor):
         n = out.shape[0]
         logprob = F.log_softmax(out, dim=1)
-        logp1 = logprob[torch.arange(n), target1]
-        logp2 = logprob[torch.arange(n), target2]
-        cross_entropy = logp1.mul_(-lam).add_(logp2, alpha=lam - 1.0)
-        return cross_entropy.mean()
+        return lam * F.nll_loss(logprob, target1) + (1.0 - lam) * F.nll_loss(logprob, target2)
 
     def forward(self, x: torch.Tensor, lam: float, target1: torch.Tensor, target2: torch.Tensor):
         # Reshape and permute the input tensor

--- a/simple_vit.py
+++ b/simple_vit.py
@@ -215,7 +215,6 @@ class SimpleVisionTransformer(nn.Module):
         return x
 
     def _loss_fn(self, out: torch.Tensor, lam: float, target1: torch.Tensor, target2: torch.Tensor):
-        n = out.shape[0]
         logprob = F.log_softmax(out, dim=1)
         return lam * F.nll_loss(logprob, target1) + (1.0 - lam) * F.nll_loss(logprob, target2)
 

--- a/transforms.py
+++ b/transforms.py
@@ -18,16 +18,27 @@ ImageOrVideo = Union[torch.Tensor, PIL.Image.Image, tv_tensors.Image, tv_tensors
 
 
 class TwoHotMixUp:
-    def __init__(self, alpha: float):
+    """This implementation of MixUp returns both targets as class indices instead of
+    class probabilities and reshape & mix-up (prefetch_factor * batch_size) samples
+    into (prefetch_factor) batches at once. Note that this does mean that (prefetch_factor)
+    batches share the same lam(bda) value.
+    """
+
+    def __init__(self, alpha: float, prefetch_factor: int, batch_size: int):
+        self.prefetch_factor = prefetch_factor
+        self.batch_size = batch_size
         self._dist = None
         if alpha:
             self._dist = torch.distributions.Beta(alpha, alpha)
 
     def __call__(self, images, labels):
+        _, *sample_shape = images.shape
+        images = images.reshape(self.prefetch_factor, self.batch_size, *sample_shape)
+        labels = labels.reshape(self.prefetch_factor, self.batch_size)
         if self._dist:
             lam = self._dist.sample()
-            images = images.roll(1, 0).mul_(1.0 - lam).add_(images, alpha=lam)
-            return images, lam, labels, labels.roll(1, 0)
+            images = images.roll(1, dims=1).mul_(1.0 - lam).add_(images, alpha=lam)
+            return images, lam, labels, labels.roll(1, dims=1)
         else:
             return images, 1, labels, labels
 


### PR DESCRIPTION
1. Stop calculating accuracies at training time
2. Compile model and loss_fn together (https://github.com/pytorch/torchtune/issues/1228)
3. Avoid running `CrossEntropyLoss()` with class probabilities with custom two-hot encoding (https://github.com/pytorch/pytorch/issues/141177)
4. Mix-up `(prefetch_factor) *` batches with the same lam(bda) value and move them to GPU at the same time

Trade-off:
1. We lose some metrics at training time, but under mixup + randaug they provide little value on top of training loss.
2. We lose some convenience at inference time that can be restored by adding an instance method.
3. No-MixUp (`--mixup-alpha=0.0`) experiment is now likely slower but that's an underperforming ablation so optimizing it isn't worth the complexity.
4. Running DDP with `n` GPUs and `--prefetch-factor=$m` now results in `m` consecutive (global) batches that are mixed-up with the same `n` distinct lam(bda) values. The default `--prefetch-factor=1` results in the same mixup behavior as that of the standard torchvision `v2.MixUp`.

We don't believe 4. matters with reasonable value of `prefetch_factor` and haven't seen evidence indicating otherwise. In fact, arguably running DDP with `n` GPUs and `--prefetch-factor=$n` is closer to the standard single GPU setup.